### PR TITLE
Skip date-only commits

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -4,6 +4,9 @@
 
 # Check to see if it has changed
 git status --short rfcs/* refs.json | grep -s "M" || exit 0
+if [ "$(git diff --raw | cut -f2)" = "rfcs/rfc-index.txt" ] && [ "$(git diff -U0 | grep '@@')" = "@@ -8 +8 @@" ]; then
+    exit 0
+fi
 
 # setup
 git config user.email mnot@mnot.net
@@ -11,14 +14,8 @@ git config user.name mnot-bot
 git remote set-url --push origin https://mnot:$GITHUB_TOKEN@github.com/mnot/rfc-refs
 git checkout -B main origin/master
 
-# Add the changes
+# Push the changes
 git add rfcs/*
 git add refs.json
-
-if [ "$(git diff --raw | cut -f2)" = "rfcs/rfc-index.txt" ] && [ "$(git diff -U0 | grep '@@')" = "@@ -8 +8 @@" ]; then
-    exit 0
-fi
-
-# Push the changes
 git commit -m "update refs"
 git push origin main

--- a/upload.sh
+++ b/upload.sh
@@ -11,8 +11,14 @@ git config user.name mnot-bot
 git remote set-url --push origin https://mnot:$GITHUB_TOKEN@github.com/mnot/rfc-refs
 git checkout -B main origin/master
 
-# Push the changes
+# Add the changes
 git add rfcs/*
 git add refs.json
+
+if [ "$(git diff --raw | cut -f2)" = "rfcs/rfc-index.txt" ] && [ "$(git diff -U0 | grep '@@')" = "@@ -8 +8 @@" ]; then
+    exit 0
+fi
+
+# Push the changes
 git commit -m "update refs"
 git push origin main


### PR DESCRIPTION
Date-only commits involve only `rfcs/rfc-index.txt:8`.

For example https://github.com/mnot/rfc-refs/commit/b6cb9ab017fd9b78b5c310c154b82649f8d0cb2a
